### PR TITLE
Fix for context chat tool

### DIFF
--- a/ex_app/lib/all_tools/lib/task_processing.py
+++ b/ex_app/lib/all_tools/lib/task_processing.py
@@ -23,7 +23,7 @@ def run_task(nc, type, task_input):
 	response = nc.ocs(
 		"POST",
 		"/ocs/v1.php/taskprocessing/schedule",
-		json={"type": "core:audio2text", "appId": "context_agent", "input": task_input},
+		json={"type": type, "appId": "context_agent", "input": task_input},
 	)
 
 	try:


### PR DESCRIPTION
If the context agent tries to call context chat it will fail due to passing the wrong type into the schedule request.