### PR TITLE
Feat: add departure time parameter

### DIFF
--- a/ex_app/lib/all_tools/external.py
+++ b/ex_app/lib/all_tools/external.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import typing
+from typing import Optional
+import datetime
+import urllib.parse
 from time import sleep
 
 import httpx
@@ -55,22 +58,24 @@ def get_tools(nc: Nextcloud):
 
 	@tool
 	@safe_tool
-	def get_public_transport_route_for_coordinates(origin_lat: str, origin_lon: str, destination_lat: str, destination_lon: str, routes: int) -> dict[str, typing.Any]:
+	def get_public_transport_route_for_coordinates(origin_lat: str, origin_lon: str, destination_lat: str, destination_lon: str, routes: int, departure_time: str | None = None):
 		"""
 		Retrieve a public transport route between two coordinates
-		When using get_public_transport_route_for_coordinates, always let the user know that the routing service here.com was used.
 		:param origin_lat: Latitude of the starting point
 		:param origin_lon: Longitude of the starting point
 		:param destination_lat: Latitude of the destination
 		:param destination_lon: Longitude of the destination
 		:param routes: the number of routes returned
-		:return: 
+		:param departure_time: time of departure, formatted like '2019-06-24T01:23:45'. Optional, leave empty for the next routes from now
+		:return: the routes, times are given in local time according to origin and destination
 		"""
 
+		if departure_time is None:
+			departure_time = urllib.parse.quote_plus(datetime.datetime.now(datetime.UTC).isoformat())
 		api_key = nc.appconfig_ex.get_value('here_api')
 		res = httpx.get('https://transit.hereapi.com/v8/routes?transportMode=car&origin=' 
 			+ origin_lat + ',' + origin_lon + '&destination=' + destination_lat + ',' + destination_lon 
-			+ '&alternatives=' + str(routes-1) + '&apikey=' + api_key)
+			+ '&alternatives=' + str(routes-1) + '&departureTime=' + departure_time + '&apikey=' + api_key)
 		json = res.json()
 		return json
 


### PR DESCRIPTION
We can now ask for connections in the future.

The requested time is interpreted in the timezone of the origin ("now" is still now). All time values in the response are returned in the timezone of each location.