### PR TITLE
Fix: app availability checks

### DIFF
--- a/ex_app/lib/all_tools/context_chat.py
+++ b/ex_app/lib/all_tools/context_chat.py
@@ -35,4 +35,5 @@ def get_category_name():
 	return "Context chat"
 
 def is_available(nc: Nextcloud):
-	return 'context_chat' in nc.apps.get_list()
+	tasktypes = nc.ocs('GET', '/ocs/v2.php/taskprocessing/tasktypes')['types'].keys()
+	return 'context_chat:context_chat' in tasktypes

--- a/ex_app/lib/all_tools/mail.py
+++ b/ex_app/lib/all_tools/mail.py
@@ -67,4 +67,8 @@ def get_category_name():
 	return "Mail"
 
 def is_available(nc: Nextcloud):
-	return 'mail' in nc.apps.get_list()
+	try: 
+		res = nc.ocs('GET', '/ocs/v2.php/apps/mail/account/list')
+	except:
+		return False
+	return True


### PR DESCRIPTION
Does not use `nc.apps.get_list()` anymore as that is only available for admins

I also realized that the calendar app is not needed to use caldav so it's not checking for it anymore