### PR TITLE
Register and invoke async tools in MCP middleware

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -195,7 +195,7 @@ jobs:
           MCP_URL="http://localhost:8080/index.php/apps/app_api/proxy/context_agent/mcp/"
           INIT_HEADERS=$(mktemp)
           INIT_BODY=$(mktemp)
-          CREDS=$(NC_PASS=alice ./occ user:add-app-password --password-from-env alice | tail -n 1)
+          CREDS=$(OC_PASS=alice ./occ user:add-app-password --password-from-env alice | tail -n 1)
 
           # Retry initialize until context_agent endpoint is responsive.
           ATTEMPT=0

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -197,6 +197,7 @@ jobs:
           INIT_BODY=$(mktemp)
           CREDS=$(OC_PASS=alice ./occ user:add-app-password --password-from-env alice | tail -n 1)
 
+          sleep 300
           # Retry initialize until context_agent endpoint is responsive.
           ATTEMPT=0
           until [ "$ATTEMPT" -ge 20 ]; do
@@ -243,7 +244,6 @@ jobs:
         env:
           CREDS: "alice:alice"
         run: |
-          sleep 300
           TASK=$(curl -X POST -u "$CREDS" -H "oCS-APIRequest: true" -H "Content-type: application/json" http://localhost:8080/ocs/v2.php/taskprocessing/schedule?format=json --data-raw '{"input": {"input": "List the files I have in Nextcloud", "confirmation":1, "conversation_token": ""},"type":"core:contextagent:interaction", "appId": "test", "customId": ""}')
           echo $TASK
           TASK_ID=$(echo $TASK | jq '.ocs.data.task.id')

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -227,7 +227,7 @@ jobs:
               -H "Accept: application/json, text/event-stream" \
               -H "Content-Type: application/json" \
               -H "oCS-APIRequest: true" \
-              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"integration-test","version":"1.0"}}}' \
+              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"integration-test","version":"1.0"}}}' \
               "$MCP_URL" || true)
 
             if [ "$STATUS" = "200" ]; then

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -201,7 +201,7 @@ jobs:
           ATTEMPT=0
           until [ "$ATTEMPT" -ge 20 ]; do
             STATUS=$(curl -sS -o "$INIT_BODY" -D "$INIT_HEADERS" -w "%{http_code}" \
-              -u "$CREDS" \
+              -H "Authorization: Bearer $CREDS" \
               -H "Accept: application/json, text/event-stream" \
               -H "Content-Type: application/json" \
               -H "oCS-APIRequest: true" \

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -195,6 +195,7 @@ jobs:
           MCP_URL="http://localhost:8080/index.php/apps/app_api/proxy/context_agent/mcp/"
           INIT_HEADERS=$(mktemp)
           INIT_BODY=$(mktemp)
+          CREDS=$(NC_PASS=alice ./occ user:add-app-password --password-from-env alice | tail -n 1)
 
           # Retry initialize until context_agent endpoint is responsive.
           ATTEMPT=0

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -218,43 +218,32 @@ jobs:
 
           sleep 300
 
-          # Retry initialize until context_agent endpoint is responsive
           ATTEMPT=0
-          INIT_BODY=$(mktemp)
           until [ "$ATTEMPT" -ge 20 ]; do
-            STATUS=$(curl -sS -o "$INIT_BODY" -w "%{http_code}" \
+            TOOLS_RESPONSE=$(curl -sS -w "\n%{http_code}" \
               -H "Authorization: Bearer $CREDS" \
               -H "Accept: application/json, text/event-stream" \
               -H "Content-Type: application/json" \
               -H "oCS-APIRequest: true" \
-              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"integration-test","version":"1.0"}}}' \
-              "$MCP_URL" || true)
+              -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+              "$MCP_URL")
+
+            STATUS=$(echo "$TOOLS_RESPONSE" | tail -1)
+            BODY=$(echo "$TOOLS_RESPONSE" | sed '$d')
 
             if [ "$STATUS" = "200" ]; then
               break
             fi
 
             ATTEMPT=$((ATTEMPT + 1))
-            echo "initialize attempt $ATTEMPT failed with status=$STATUS, retrying..."
-            cat "$INIT_BODY"
+            echo "tools/list attempt $ATTEMPT failed with status=$STATUS, retrying..."
+            echo "$BODY"
             sleep 3
           done
 
           [ "$STATUS" = "200" ]
-          echo "Initialize response:"
-          cat "$INIT_BODY"
-
-          # In stateless mode, no session ID needed — just send tools/list directly
-          TOOLS_RESPONSE=$(curl -sS \
-            -H "Authorization: Bearer $CREDS" \
-            -H "Accept: application/json, text/event-stream" \
-            -H "Content-Type: application/json" \
-            -H "oCS-APIRequest: true" \
-            -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
-            "$MCP_URL")
-
-          echo "$TOOLS_RESPONSE"
-          echo "$TOOLS_RESPONSE" | grep -q 'list_calendars'
+          echo "$BODY"
+          echo "$BODY" | grep -q 'list_calendars'
 
       - name: Run task
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -186,6 +186,57 @@ jobs:
         run: |
           ./occ app_api:app:register context_agent manual_install --json-info "{\"appid\":\"context_agent\",\"name\":\"Nextcloud Assistant Context Agent\",\"daemon_config_name\":\"manual_install\",\"version\":\"${{ fromJson(steps.context_agent_appinfo.outputs.result).version }}\",\"secret\":\"12345\",\"port\":9081,\"scopes\":[\"AI_PROVIDERS\", \"TASK_PROCESSING\"],\"system_app\":0}" --force-scopes --wait-finish
 
+      - name: Verify MCP tool discovery includes async calendar tools
+        env:
+          CREDS: "alice:alice"
+        run: |
+          set -euo pipefail
+
+          MCP_URL="http://localhost:8080/index.php/apps/app_api/proxy/context_agent/mcp/"
+          INIT_HEADERS=$(mktemp)
+          INIT_BODY=$(mktemp)
+
+          # Retry initialize until context_agent endpoint is responsive.
+          ATTEMPT=0
+          until [ "$ATTEMPT" -ge 20 ]; do
+            STATUS=$(curl -sS -o "$INIT_BODY" -D "$INIT_HEADERS" -w "%{http_code}" \
+              -u "$CREDS" \
+              -H "Accept: application/json, text/event-stream" \
+              -H "Content-Type: application/json" \
+              -H "oCS-APIRequest: true" \
+              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"integration-test","version":"1.0"}}}' \
+              "$MCP_URL" || true)
+
+            if [ "$STATUS" = "200" ]; then
+              break
+            fi
+
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "initialize attempt $ATTEMPT failed with status=$STATUS, retrying..."
+            sleep 3
+          done
+
+          [ "$STATUS" = "200" ]
+
+          SESSION_ID=$(grep -i '^mcp-session-id:' "$INIT_HEADERS" | awk '{print $2}' | tr -d '\r')
+          if [ -z "$SESSION_ID" ]; then
+            echo "Missing mcp-session-id in initialize response"
+            cat "$INIT_HEADERS"
+            exit 1
+          fi
+
+          TOOLS_RESPONSE=$(curl -sS \
+            -u "$CREDS" \
+            -H "Accept: application/json, text/event-stream" \
+            -H "Content-Type: application/json" \
+            -H "oCS-APIRequest: true" \
+            -H "mcp-session-id: $SESSION_ID" \
+            -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+            "$MCP_URL")
+
+          echo "$TOOLS_RESPONSE"
+          echo "$TOOLS_RESPONSE" | grep -q 'list_calendars'
+
 
       - name: Run task
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -214,15 +214,15 @@ jobs:
           set -euo pipefail
 
           MCP_URL="http://localhost:8080/index.php/apps/app_api/proxy/context_agent/mcp/"
-          INIT_HEADERS=$(mktemp)
-          INIT_BODY=$(mktemp)
           CREDS=$(OC_PASS=alice ./occ user:add-app-password --password-from-env alice | tail -n 1)
 
           sleep 300
-          # Retry initialize until context_agent endpoint is responsive.
+
+          # Retry initialize until context_agent endpoint is responsive
           ATTEMPT=0
+          INIT_BODY=$(mktemp)
           until [ "$ATTEMPT" -ge 20 ]; do
-            STATUS=$(curl -sS -o "$INIT_BODY" -D "$INIT_HEADERS" -w "%{http_code}" \
+            STATUS=$(curl -sS -o "$INIT_BODY" -w "%{http_code}" \
               -H "Authorization: Bearer $CREDS" \
               -H "Accept: application/json, text/event-stream" \
               -H "Content-Type: application/json" \
@@ -236,30 +236,25 @@ jobs:
 
             ATTEMPT=$((ATTEMPT + 1))
             echo "initialize attempt $ATTEMPT failed with status=$STATUS, retrying..."
+            cat "$INIT_BODY"
             sleep 3
           done
 
           [ "$STATUS" = "200" ]
+          echo "Initialize response:"
+          cat "$INIT_BODY"
 
-          SESSION_ID=$(grep -i '^mcp-session-id:' "$INIT_HEADERS" | awk '{print $2}' | tr -d '\r')
-          if [ -z "$SESSION_ID" ]; then
-            echo "Missing mcp-session-id in initialize response"
-            cat "$INIT_HEADERS"
-            exit 1
-          fi
-
+          # In stateless mode, no session ID needed — just send tools/list directly
           TOOLS_RESPONSE=$(curl -sS \
             -H "Authorization: Bearer $CREDS" \
             -H "Accept: application/json, text/event-stream" \
             -H "Content-Type: application/json" \
             -H "oCS-APIRequest: true" \
-            -H "mcp-session-id: $SESSION_ID" \
             -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
             "$MCP_URL")
 
           echo "$TOOLS_RESPONSE"
           echo "$TOOLS_RESPONSE" | grep -q 'list_calendars'
-
 
       - name: Run task
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -227,7 +227,7 @@ jobs:
           fi
 
           TOOLS_RESPONSE=$(curl -sS \
-            -u "$CREDS" \
+            -H "Authorization: Bearer $CREDS" \
             -H "Accept: application/json, text/event-stream" \
             -H "Content-Type: application/json" \
             -H "oCS-APIRequest: true" \

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -184,7 +184,28 @@ jobs:
 
       - name: Register backend
         run: |
-          ./occ app_api:app:register context_agent manual_install --info-xml "$GITHUB_WORKSPACE/context_agent/appinfo/info.xml" --force-scopes --wait-finish
+          ./occ app_api:app:register context_agent manual_install --json-info \
+            "$(jq -nc \
+              --arg version "${{ fromJson(steps.context_agent_appinfo.outputs.result).version }}" \
+              '{
+                appid: "context_agent",
+                name: "Nextcloud Assistant Context Agent",
+                daemon_config_name: "manual_install",
+                version: $version,
+                secret: "12345",
+                port: 9081,
+                scopes: ["AI_PROVIDERS", "TASK_PROCESSING"],
+                system_app: 0,
+                routes: [
+                  {
+                    url: "mcp",
+                    verb: "POST,GET,DELETE",
+                    access_level: "USER",
+                    headers_to_exclude: "[]"
+                  }
+                ]
+              }'
+            )" --force-scopes --wait-finish
 
       - name: Verify MCP tool discovery includes async calendar tools
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Register backend
         run: |
-          ./occ app_api:app:register context_agent manual_install --json-info "{\"appid\":\"context_agent\",\"name\":\"Nextcloud Assistant Context Agent\",\"daemon_config_name\":\"manual_install\",\"version\":\"${{ fromJson(steps.context_agent_appinfo.outputs.result).version }}\",\"secret\":\"12345\",\"port\":9081,\"scopes\":[\"AI_PROVIDERS\", \"TASK_PROCESSING\"],\"system_app\":0}" --force-scopes --wait-finish
+          ./occ app_api:app:register context_agent manual_install --info-xml "$GITHUB_WORKSPACE/context_agent/appinfo/info.xml" --force-scopes --wait-finish
 
       - name: Verify MCP tool discovery includes async calendar tools
         env:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -200,7 +200,7 @@ jobs:
                   {
                     url: "mcp",
                     verb: "POST,GET,DELETE",
-                    access_level: "USER",
+                    access_level: 1,
                     headers_to_exclude: "[]"
                   }
                 ]

--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -34,8 +34,7 @@ from fastmcp import FastMCP
 mcp = FastMCP(name="nextcloud")
 mcp.add_middleware(UserAuthMiddleware())
 mcp.add_middleware(ToolListMiddleware(mcp))
-mcp.stateless_http = True
-http_mcp_app = mcp.http_app("/", transport="http")
+http_mcp_app = mcp.http_app("/", transport="http", stateless_http=True)
 
 fast_app = FastAPI(lifespan=http_mcp_app.lifespan)
 

--- a/ex_app/lib/mcp_server.py
+++ b/ex_app/lib/mcp_server.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 LangChain, Inc.
 # SPDX-License-Identifier: MIT
 import time
+import asyncio
+import inspect
 from functools import wraps
 
 from fastmcp.server.dependencies import get_context
@@ -58,22 +60,37 @@ class ToolListMiddleware(Middleware):
 				for tool in tools.keys():
 					self.mcp.remove_tool(tool)
 				for tool in safe + dangerous:
-					if not hasattr(tool, "func") or tool.func is None:
+					tool_action = getattr(tool, "coroutine", None) or getattr(tool, "func", None)
+					if tool_action is None:
 						continue
-					self.mcp.tool()(mcp_tool(tool.func))
+					tool_name = getattr(tool, "name", None)
+					if tool_name:
+						self.mcp.tool(name=tool_name)(mcp_tool(tool_action, tool_name=tool_name))
+					else:
+						self.mcp.tool()(mcp_tool(tool_action))
 				LAST_MCP_TOOL_UPDATE = time.time()
 		return await call_next(context)
 
 # Regenerates the tools with the correct nc object
-def mcp_tool(tool):
+def mcp_tool(tool, tool_name: str | None = None):
 	@wraps(tool)
 	async def wrapper(*args, **kwargs):
 		ctx = get_context()
 		nc = ctx.get_state('nextcloud')
 		safe, dangerous = await get_tools(nc)
 		tools = safe + dangerous
+		invoked_name = tool_name or tool.__name__
 		for t in tools:
-			if hasattr(t, "func") and t.func and t.name == tool.__name__:
-				return t.func(*args, **kwargs)
+			action = getattr(t, "coroutine", None) or getattr(t, "func", None)
+			if action is None:
+				continue
+			candidate_name = getattr(t, "name", None) or getattr(action, "__name__", None)
+			if candidate_name == invoked_name:
+				if inspect.iscoroutinefunction(action):
+					return await action(*args, **kwargs)
+				result = await asyncio.to_thread(action, *args, **kwargs)
+				if inspect.isawaitable(result):
+					return await result
+				return result
 		raise RuntimeError("Tool not found")
 	return wrapper


### PR DESCRIPTION
## Scope
- Endpoint: `https://mynextclouddomain/index.php/apps/app_api/proxy/context_agent/mcp/`
- Focus: OpenWebUI symptoms and the patch that fixed them.

## Symptoms (Before Fix)
- [OpenWebUI](https://github.com/open-webui/open-webui) could verify/connect to the MCP endpoint, but usable tools (for example calendar) did not appear.
- `tools/list` could return empty even with valid `tool_status` (including `calendar: true`).
- Logs showed async/runtime mismatch behavior during MCP tool path execution.

## Root Cause
- MCP registration in `ex_app/lib/mcp_server.py` only handled `tool.func`.
- Many context_agent tools are async and exposed via `tool.coroutine`.
- Async tools were skipped during registration, so discovery could be empty.
- Middleware state also needed an async client (`AsyncNextcloudApp`) to avoid runtime mismatch.

## Patch Applied
- File patched: `ex_app/lib/mcp_server.py`

### 1) Registration fix
- Register tools from either async or sync callable:
  - `tool_action = getattr(tool, "coroutine", None) or getattr(tool, "func", None)`
- Preserve MCP tool names during registration.

### 2) Invocation fix
- Resolve and invoke tools by registered name for both async and sync callables.
- Await async callables correctly.

### 3) Runtime fix in middleware
- Store `AsyncNextcloudApp()` in MCP state.
- Await user assignment: `await nc.set_user(user)`.

## Deployment
- Hotfix image built from `nc/context-agent-hotfix/Dockerfile`.
- Pushed to local registry: `localhost:5001/nextcloud/context_agent:2.5.1`.
- App re-enabled/re-registered to pick up patched image.

## Upstream Status
- Patch pushed to `pledou/context_agent` on `main`.
- Commit: `abeea46`.
- Message: `fix(mcp): register and invoke async tools in MCP middleware`.

## Verification
- Transport/auth still healthy (HTTPS, auth, SSE, initialize).
- Session lifecycle works with header `mcp-session-id`.
- OpenWebUI verify flow (`POST`/`GET`/`DELETE`) succeeds.
- Async MCP tool path is now patched (registration + invocation + runtime client type).

## Current Status
- MCP transport: ✅ Working
- MCP async tool path: ✅ Fixed
- OpenWebUI integration: ✅ Working path restored (with patch)

## Quick Protocol Note
- Correct follow-up session header is `mcp-session-id`.
- Using `X-MCP-Session` can create false negatives during testing.