### PR TITLE
feat(deck): Add card discovery (list_board_cards) and card comment tools

### DIFF
--- a/ex_app/lib/all_tools/deck.py
+++ b/ex_app/lib/all_tools/deck.py
@@ -25,7 +25,57 @@ async def get_tools(nc: AsyncNextcloudApp):
 
 		return json.dumps(response.json())
 
-	
+	@tool
+	@safe_tool
+	async def list_board_cards(board_id: int, stack_id: Optional[int] = None):
+		"""
+		List all cards in a Deck board with their metadata.
+		Each card includes its id (needed for add_card_comment, add_card_label, assign_card_to_user, delete_card),
+		title, description, stack, labels, assignees, due date, archived status, and done status.
+		Use this tool to find cards when the agent only knows a card by name or context, not by id.
+		:param board_id: the id of the board (obtainable with list_boards)
+		:param stack_id: optional - filter to cards in this specific stack only (obtainable with list_boards)
+		:return: list of cards with id, title, description, stack_id, stack_title, labels, assignees, due_date, archived, done, comments_count
+		"""
+		response = await nc._session._create_adapter().request('GET', f"{nc.app_cfg.endpoint}/index.php/apps/deck/api/v1.0/boards/{board_id}/stacks", headers={
+			"Content-Type": "application/json",
+			"OCS-APIREQUEST": "true",
+		})
+		stacks = response.json()
+
+		cards = []
+		for stack in stacks:
+			if stack_id is not None and stack['id'] != stack_id:
+				continue
+			for card in stack.get('cards', []):
+				labels = []
+				for label in card.get('labels', []):
+					labels.append({
+						'id': label['id'],
+						'title': label['title'],
+						'color': label['color'],
+					})
+				assignees = []
+				for assignment in card.get('assignedUsers', []):
+					participant = assignment.get('participant', {})
+					assignees.append({
+						'uid': participant.get('uid'),
+						'displayname': participant.get('displayname'),
+					})
+				cards.append({
+					'id': card['id'],
+					'title': card['title'],
+					'description': card.get('description', ''),
+					'stack_id': stack['id'],
+					'stack_title': stack['title'],
+					'labels': labels,
+					'assignees': assignees,
+					'due_date': card.get('duedate'),
+					'archived': card.get('archived', False),
+					'done': card.get('done'),
+					'comments_count': card.get('commentsCount', 0),
+				})
+		return json.dumps(cards)
 
 	@tool
 	@dangerous_tool
@@ -65,7 +115,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Add a label to a card
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card (obtainable with list_boards)
+		:param card_id: the id of the card (obtainable with list_board_cards)
 		:param label_id: the id of the label to add (obtainable with list_boards - labels are listed in board details)
 		:return: success confirmation
 		"""
@@ -85,7 +135,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Assign a card to a user
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card (obtainable with list_boards)
+		:param card_id: the id of the card (obtainable with list_board_cards)
 		:param user_id: the user id to assign the card to
 		:return: success confirmation
 		"""
@@ -105,7 +155,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Delete a card from a board
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card to delete (obtainable with list_boards)
+		:param card_id: the id of the card to delete (obtainable with list_board_cards)
 		:return: success confirmation
 		"""
 		response = await nc._session._create_adapter().request('DELETE', f"{nc.app_cfg.endpoint}/index.php/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}", headers={
@@ -115,12 +165,74 @@ async def get_tools(nc: AsyncNextcloudApp):
 
 		return json.dumps(response.json())
 
+	# --- Card Comments (OCS API) ---
+
+	@tool
+	@safe_tool
+	async def list_card_comments(card_id: int, limit: int = 20, offset: int = 0):
+		"""
+		List all comments on a Deck card
+		:param card_id: the id of the card (obtainable with list_board_cards)
+		:param limit: maximum number of comments to return (default 20)
+		:param offset: pagination offset (default 0)
+		:return: list of comments with id, message, author, and creation date
+		"""
+		return await nc.ocs('GET', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', params={
+			'limit': limit,
+			'offset': offset,
+		})
+
+	@tool
+	@dangerous_tool
+	async def add_card_comment(card_id: int, message: str, parent_id: Optional[int] = None):
+		"""
+		Add a comment to a Deck card
+		:param card_id: the id of the card (obtainable with list_board_cards)
+		:param message: the comment text (max 1000 characters)
+		:param parent_id: optional id of a parent comment for threaded replies (obtainable with list_card_comments)
+		:return: the created comment
+		"""
+		payload = {'message': message}
+		if parent_id is not None:
+			payload['parentId'] = parent_id
+		return await nc.ocs('POST', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', json=payload)
+
+	@tool
+	@dangerous_tool
+	async def update_card_comment(card_id: int, comment_id: int, message: str):
+		"""
+		Update an existing comment on a Deck card. Only the comment author can update their own comments.
+		:param card_id: the id of the card (obtainable with list_board_cards)
+		:param comment_id: the id of the comment to update (obtainable with list_card_comments)
+		:param message: the new comment text (max 1000 characters)
+		:return: the updated comment
+		"""
+		return await nc.ocs('PUT', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}', json={
+			'message': message,
+		})
+
+	@tool
+	@dangerous_tool
+	async def delete_card_comment(card_id: int, comment_id: int):
+		"""
+		Delete a comment from a Deck card. Only the comment author can delete their own comments.
+		:param card_id: the id of the card (obtainable with list_board_cards)
+		:param comment_id: the id of the comment to delete (obtainable with list_card_comments)
+		:return: confirmation of deletion
+		"""
+		return await nc.ocs('DELETE', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}')
+
 	return [
 		list_boards,
+		list_board_cards,
 		add_card,
 		add_card_label,
 		assign_card_to_user,
-		delete_card
+		delete_card,
+		list_card_comments,
+		add_card_comment,
+		update_card_comment,
+		delete_card_comment,
 	]
 
 def get_category_name():

--- a/ex_app/lib/all_tools/deck.py
+++ b/ex_app/lib/all_tools/deck.py
@@ -192,7 +192,8 @@ async def get_tools(nc: AsyncNextcloudApp):
 		:param parent_id: optional id of a parent comment for threaded replies (obtainable with list_card_comments)
 		:return: the created comment
 		"""
-		payload = {'message': message}
+		message_with_ai_note = f"{message}\n\nPosted by Nextcloud AI Assistant."
+		payload = {'message': message_with_ai_note}
 		if parent_id is not None:
 			payload['parentId'] = parent_id
 		return await nc.ocs('POST', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', json=payload)
@@ -207,8 +208,9 @@ async def get_tools(nc: AsyncNextcloudApp):
 		:param message: the new comment text (max 1000 characters)
 		:return: the updated comment
 		"""
+		message_with_ai_note = f"{message}\n\nEdited by Nextcloud AI Assistant."
 		return await nc.ocs('PUT', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}', json={
-			'message': message,
+			'message': message_with_ai_note,
 		})
 
 	@tool

--- a/ex_app/lib/all_tools/deck.py
+++ b/ex_app/lib/all_tools/deck.py
@@ -177,10 +177,10 @@ async def get_tools(nc: AsyncNextcloudApp):
 		:param offset: pagination offset (default 0)
 		:return: list of comments with id, message, author, and creation date
 		"""
-		return await nc.ocs('GET', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', params={
+		return json.dumps(await nc.ocs('GET', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', params={
 			'limit': limit,
 			'offset': offset,
-		})
+		}))
 
 	@tool
 	@dangerous_tool
@@ -196,7 +196,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		payload = {'message': message_with_ai_note}
 		if parent_id is not None:
 			payload['parentId'] = parent_id
-		return await nc.ocs('POST', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', json=payload)
+		return json.dumps(await nc.ocs('POST', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments', json=payload))
 
 	@tool
 	@dangerous_tool
@@ -209,9 +209,9 @@ async def get_tools(nc: AsyncNextcloudApp):
 		:return: the updated comment
 		"""
 		message_with_ai_note = f"{message}\n\nEdited by Nextcloud AI Assistant."
-		return await nc.ocs('PUT', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}', json={
+		return json.dumps(await nc.ocs('PUT', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}', json={
 			'message': message_with_ai_note,
-		})
+		}))
 
 	@tool
 	@dangerous_tool
@@ -222,7 +222,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		:param comment_id: the id of the comment to delete (obtainable with list_card_comments)
 		:return: confirmation of deletion
 		"""
-		return await nc.ocs('DELETE', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}')
+		return json.dumps(await nc.ocs('DELETE', f'/ocs/v2.php/apps/deck/api/v1.0/cards/{card_id}/comments/{comment_id}'))
 
 	return [
 		list_boards,


### PR DESCRIPTION
## Summary

- Adds a new `list_board_cards` safe tool that lists cards in a Deck board with structured metadata (stack, labels, assignees, due date, archived status, done status, comments count)
- Adds 4 new card comment tools: `list_card_comments`, `add_card_comment`, `update_card_comment`, `delete_card_comment`
- Comments use the Deck OCS API, accessed via `nc.ocs()` (same pattern as `shares.py`); comment endpoints support threaded replies via optional `parent_id` on `add_card_comment`
- Updates three existing docstrings (`add_card_label`, `assign_card_to_user`, `delete_card`) to point `card_id` lookups at `list_board_cards` instead of `list_boards`, which does not actually return cards

## Motivation

Two gaps in one PR, in the same file:

**Card discovery** was raised in #127 during review:

> Deck assign card (impossible to target an existing card by name, it only works right after a card has been added so the agent knows its ID, there could be a "list board cards" tool with an optional list ID param)

The unified search tool works for keyword lookups but does not enumerate cards in a board and does not return the structured metadata (stack, labels, assignees, due date, archived) that an agent typically needs to reason about which card to act on. `list_board_cards` fills that gap.

**Card comments** are a core Deck collaboration feature — users discuss tasks directly on cards. The existing Deck tools only support board/card/label/assignment operations but cannot read or write comments. This is a common request when using the AI assistant to interact with project boards.

## Implementation Details

### Disclaimer

Implementation from a technical perspective was done mainly by a LLM (Claude Opus 4.7 max effort). 
Every tool and endpoint response shape was validated end-to-end against Nextcloud 32.0.8 + Deck 1.16.3, with a full lifecycle smoke test completed before opening the PR.

### list_board_cards

Uses the existing REST endpoint `GET /index.php/apps/deck/api/v1.0/boards/{board_id}/stacks`, which already returns cards nested inside stacks. The tool flattens that shape for agent consumption and strips internal fields (`ETag`, `lastModified`, `order`, `referenceData`, `attachments`, `overdue`, `type`, `owner`, `commentsUnread`, `deletedAt`) that are not relevant for tool use.

Returned shape:

```python
[
  {
    "id": 6,
    "title": "Implement TOTP 2FA support",
    "description": "...",
    "stack_id": 5,
    "stack_title": "Backlog",
    "labels": [{"id": 5, "title": "Read more inside", "color": "CC317C"}],
    "assignees": [{"uid": "admin", "displayname": "admin"}],
    "due_date": "2026-03-15T00:00:00+00:00",
    "archived": false,
    "done": null,
    "comments_count": 2
  },
  ...
]
```

Parameters:
- `board_id: int` (required) — obtainable with `list_boards`
- `stack_id: Optional[int]` — optional client-side filter to a single stack; useful for "what's in the To Do column"

Decorator: `@safe_tool` (read-only).

### Card comments

The Deck app registers comment endpoints as **OCS routes** (in `appinfo/routes.php` under the `'ocs'` key), so these tools use `nc.ocs()` rather than the adapter-based HTTP calls used by the existing board/card tools. This is consistent with how `shares.py` and `contacts.py` handle OCS endpoints.

| Tool | Decorator | OCS Endpoint |
|------|-----------|-------------|
| `list_card_comments` | `@safe_tool` | `GET /ocs/v2.php/apps/deck/api/v1.0/cards/{cardId}/comments` |
| `add_card_comment` | `@dangerous_tool` | `POST /ocs/v2.php/apps/deck/api/v1.0/cards/{cardId}/comments` |
| `update_card_comment` | `@dangerous_tool` | `PUT /ocs/v2.php/apps/deck/api/v1.0/cards/{cardId}/comments/{commentId}` |
| `delete_card_comment` | `@dangerous_tool` | `DELETE /ocs/v2.php/apps/deck/api/v1.0/cards/{cardId}/comments/{commentId}` |

## Test Plan

Tested against Nextcloud 32.0.8 + Deck 1.16.4:

**list_board_cards:**
- [x] Returns all cards in a board (35 cards across 5 stacks on test board)
- [x] `stack_id` filter correctly limits to one stack (19 cards, all with `stack_id == 5`)
- [x] Cards with labels return `[{id, title, color}]` shape
- [x] Cards with assignees return `[{uid, displayname}]` shape (verified via assign/unassign round-trip)
- [x] `due_date` returns ISO 8601 or null
- [x] `archived`, `done`, `comments_count` present on every card
- [x] Non-existent `stack_id` returns empty list (no error)

**Card comments:**
- [x] Tested all 4 endpoints against Nextcloud 32.0.8 with curl
- [x] Verified create returns comment with id, message, actorId, creationDateTime
- [x] Verified list returns array of comments
- [x] Verified update changes message text, returns updated comment
- [x] Verified delete returns empty data, subsequent list confirms removal
- [x] Verified threaded reply support (parentId parameter)
- [x] Integration test with Context Agent MCP server (requires running ExApp)