### PR TITLE
feat(deck): Add list_board_cards tool for card discovery

### DIFF
--- a/ex_app/lib/all_tools/deck.py
+++ b/ex_app/lib/all_tools/deck.py
@@ -25,7 +25,57 @@ async def get_tools(nc: AsyncNextcloudApp):
 
 		return json.dumps(response.json())
 
-	
+	@tool
+	@safe_tool
+	async def list_board_cards(board_id: int, stack_id: Optional[int] = None):
+		"""
+		List all cards in a Deck board with their metadata.
+		Each card includes its id (needed for add_card_comment, add_card_label, assign_card_to_user, delete_card),
+		title, description, stack, labels, assignees, due date, archived status, and done status.
+		Use this tool to find cards when the agent only knows a card by name or context, not by id.
+		:param board_id: the id of the board (obtainable with list_boards)
+		:param stack_id: optional - filter to cards in this specific stack only (obtainable with list_boards)
+		:return: list of cards with id, title, description, stack_id, stack_title, labels, assignees, due_date, archived, done, comments_count
+		"""
+		response = await nc._session._create_adapter().request('GET', f"{nc.app_cfg.endpoint}/index.php/apps/deck/api/v1.0/boards/{board_id}/stacks", headers={
+			"Content-Type": "application/json",
+			"OCS-APIREQUEST": "true",
+		})
+		stacks = response.json()
+
+		cards = []
+		for stack in stacks:
+			if stack_id is not None and stack['id'] != stack_id:
+				continue
+			for card in stack.get('cards', []):
+				labels = []
+				for label in card.get('labels', []):
+					labels.append({
+						'id': label['id'],
+						'title': label['title'],
+						'color': label['color'],
+					})
+				assignees = []
+				for assignment in card.get('assignedUsers', []):
+					participant = assignment.get('participant', {})
+					assignees.append({
+						'uid': participant.get('uid'),
+						'displayname': participant.get('displayname'),
+					})
+				cards.append({
+					'id': card['id'],
+					'title': card['title'],
+					'description': card.get('description', ''),
+					'stack_id': stack['id'],
+					'stack_title': stack['title'],
+					'labels': labels,
+					'assignees': assignees,
+					'due_date': card.get('duedate'),
+					'archived': card.get('archived', False),
+					'done': card.get('done'),
+					'comments_count': card.get('commentsCount', 0),
+				})
+		return json.dumps(cards)
 
 	@tool
 	@dangerous_tool
@@ -65,7 +115,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Add a label to a card
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card (obtainable with list_boards)
+		:param card_id: the id of the card (obtainable with list_board_cards)
 		:param label_id: the id of the label to add (obtainable with list_boards - labels are listed in board details)
 		:return: success confirmation
 		"""
@@ -85,7 +135,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Assign a card to a user
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card (obtainable with list_boards)
+		:param card_id: the id of the card (obtainable with list_board_cards)
 		:param user_id: the user id to assign the card to
 		:return: success confirmation
 		"""
@@ -105,7 +155,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 		Delete a card from a board
 		:param board_id: the id of the board (obtainable with list_boards)
 		:param stack_id: the id of the stack (obtainable with list_boards)
-		:param card_id: the id of the card to delete (obtainable with list_boards)
+		:param card_id: the id of the card to delete (obtainable with list_board_cards)
 		:return: success confirmation
 		"""
 		response = await nc._session._create_adapter().request('DELETE', f"{nc.app_cfg.endpoint}/index.php/apps/deck/api/v1.0/boards/{board_id}/stacks/{stack_id}/cards/{card_id}", headers={
@@ -117,6 +167,7 @@ async def get_tools(nc: AsyncNextcloudApp):
 
 	return [
 		list_boards,
+		list_board_cards,
 		add_card,
 		add_card_label,
 		assign_card_to_user,


### PR DESCRIPTION
## Summary

- Adds a new `list_board_cards` safe tool that lists cards in a Deck board with structured metadata (stack, labels, assignees, due date, archived status, done status, comments count)
- Fills the gap where the agent cannot target an existing card by name — it previously had to rely on search, or only knew card ids for cards it had just created via `add_card`
- Updates three existing docstrings to point at `list_board_cards` for card_id discovery (they previously pointed at `list_boards`, which does not return cards)

## Motivation

This gap was raised in #127 during review:

> Deck assign card (impossible to target an existing card by name, it only works right after a card has been added so the agent knows its ID, there could be a "list board cards" tool with an optional list ID param)

The unified search tool works for keyword lookups but does not enumerate cards in a board and does not return the structured metadata (stack, labels, assignees, due date, archived) that an agent typically needs to reason about which card to act on.

This PR adds exactly the tool suggested, and makes the three dependent tools (`add_card_label`, `assign_card_to_user`, `delete_card`) discoverable from it.

## Implementation Details

### Endpoint

`GET /index.php/apps/deck/api/v1.0/boards/{board_id}/stacks` — already exposes cards nested inside stacks. Same REST adapter pattern as the other Deck tools, with `OCS-APIREQUEST: true` for CSRF bypass.

### Returned shape

```python
[
  {
    "id": 6,
    "title": "Implement TOTP 2FA support",
    "description": "...",
    "stack_id": 5,
    "stack_title": "Backlog",
    "labels": [{"id": 5, "title": "Read more inside", "color": "CC317C"}],
    "assignees": [{"uid": "admin", "displayname": "admin"}],
    "due_date": "2026-03-15T00:00:00+00:00",
    "archived": false,
    "done": null,
    "comments_count": 2
  },
  ...
]
```

Internal fields (`ETag`, `lastModified`, `order`, `referenceData`, `attachments`, `overdue`, `type`, `owner`, `commentsUnread`, `deletedAt`) are stripped since they are not relevant for tool use by the agent.

### Parameters

- `board_id: int` (required) — obtainable with `list_boards`
- `stack_id: Optional[int]` — optional client-side filter to a single stack; useful for "what's in the To Do column"

### Decorator

`@safe_tool` — read-only operation.

## Test Plan

Tested against Nextcloud 32.0.8 + Deck 1.16.4:

- [x] Returns all cards in a board (35 cards across 5 stacks on test board)
- [x] `stack_id` filter correctly limits to one stack (19 cards, all with `stack_id == 5`)
- [x] Cards with labels return `[{id, title, color}]` shape
- [x] Cards with assignees return `[{uid, displayname}]` shape (verified via assign/unassign round-trip)
- [x] `due_date` returns ISO 8601 or null
- [x] `archived`, `done`, `comments_count` present on every card
- [x] Non-existent `stack_id` returns empty list (no error)
- [ ] Integration test with Context Agent MCP server (requires running ExApp)

## Note

Implementation was AI-assisted (Claude). I reviewed each change, tested all response shapes against Nextcloud 32.0.8 + Deck 1.16.4, and verified end-to-end behavior before opening the PR.